### PR TITLE
Bug fix

### DIFF
--- a/namemcpy/namemc.py
+++ b/namemcpy/namemc.py
@@ -285,7 +285,7 @@ class namepy():
         if current == False:
             try:
                 skin_hash_list.remove('javascript:void(0)') # just have to get rid of something that stays in the code idk y
-            except ValueError:
+            except:
                 pass
 
         for s in skin_hash_list:


### PR DESCRIPTION
For some reason this error occurs, so this should be a _very_ simple fix.

`    skin_hash_list.remove('javascript:void(0)') # just have to get rid of something that stays in the code idk y
ValueError: list.remove(x): x not in list`